### PR TITLE
convert from esm to the format required by the Ethereum tests repo

### DIFF
--- a/bin/formatterForTest
+++ b/bin/formatterForTest
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+
+var fs = require('fs'),
+  parseArgs = require('minimist')
+  bignum = require('bignum');
+
+var argv = parseArgs(process.argv.slice(2));
+
+var fromEsmExport = require(argv._[0]);
+
+var formatForTests = {};
+
+for (account in fromEsmExport) {
+  formatForTests[account] = { 'code': '0x' + fromEsmExport[account].code };
+
+  formatForTests[account].nonce = bignum(fromEsmExport[account].nonce).toString();
+
+  formatForTests[account].balance = bignum(fromEsmExport[account].balance).toString();
+
+  formatForTests[account].storage = {};
+  for (key in fromEsmExport[account].storage) {
+    formatForTests[account].storage['0x'+key] = '0x'+fromEsmExport[account].storage[key];
+  }
+}
+
+console.log(JSON.stringify(formatForTests));

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "JSONStream": "^0.9.0",
     "async": "^0.9.0",
+    "bignum": "^0.9.2",
     "columnify": "^1.4.1",
     "ethereumjs-lib": "^0.1.6",
     "level": "^0.18.0",


### PR DESCRIPTION
nonces and balances are base10
storage and code are prefixed with 0x